### PR TITLE
Add back button press handling on android

### DIFF
--- a/android/src/main/java/kr/iamport/capacitor/IamportActivity.java
+++ b/android/src/main/java/kr/iamport/capacitor/IamportActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
@@ -68,5 +69,17 @@ public class IamportActivity extends Activity {
         if (requestCode == IamportCapacitor.REQUEST_CODE_FOR_NICE_TRANS) {
             webViewClient.bankPayPostProcess(requestCode, resultCode, data);
         }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            Intent intent = new Intent();
+            intent.putExtra("error", "user cancelled");
+            this.setResult(Activity.RESULT_CANCELED, intent);
+            this.finish();
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
     }
 }

--- a/android/src/main/java/kr/iamport/capacitor/IamportCapacitor.java
+++ b/android/src/main/java/kr/iamport/capacitor/IamportCapacitor.java
@@ -1,5 +1,6 @@
 package kr.iamport.capacitor;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -42,6 +43,9 @@ public class IamportCapacitor extends Plugin {
         super.handleOnActivityResult(requestCode, resultCode, data);
 
         if (requestCode == REQUEST_CODE) {
+            if (resultCode == Activity.RESULT_CANCELED) {
+                return;
+            }
             Bundle extras = data.getExtras();
             String url = extras.getString("url");
 


### PR DESCRIPTION
Resolve #11

Android IamportActivity에서 webview가 생성된 후에 back button press 시 handleOnActivityResult로 null intent가 전달되면서
아래와 같은 에러가 발생합니다.
```
java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Bundle android.content.Intent.getExtras()' on a null object reference
        at kr.iamport.capacitor.IamportCapacitor.handleOnActivityResult(IamportCapacitor.java:45)
        at com.getcapacitor.Bridge.onActivityResult(Bridge.java:776)
        at com.getcapacitor.BridgeActivity.onActivityResult(BridgeActivity.java:214)
        at android.app.Activity.dispatchActivityResult(Activity.java:8110)
        at android.app.ActivityThread.deliverResults(ActivityThread.java:4838)
```

### Full stacktrace
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.woot.wootAppRelease, PID: 13011
    java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=6018, result=0, data=null} to activity {com.woot.wootAppRelease/com.woot.wootAppRelease.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Bundle android.content.Intent.getExtras()' on a null object reference
        at android.app.ActivityThread.deliverResults(ActivityThread.java:4845)
        at android.app.ActivityThread.handleSendResult(ActivityThread.java:4886)
        at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Bundle android.content.Intent.getExtras()' on a null object reference
        at kr.iamport.capacitor.IamportCapacitor.handleOnActivityResult(IamportCapacitor.java:45)
        at com.getcapacitor.Bridge.onActivityResult(Bridge.java:776)
        at com.getcapacitor.BridgeActivity.onActivityResult(BridgeActivity.java:214)
        at android.app.Activity.dispatchActivityResult(Activity.java:8110)
        at android.app.ActivityThread.deliverResults(ActivityThread.java:4838)
```